### PR TITLE
ARQ-198: Adicionada composite action bucket-publish-jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,19 @@
 # Reusable Workflows
 
-Repositório utilizado para criação de Workflows Actions reutilizáveis
+Repositório utilizado para criação de Workflows Actions reutilizáveis e composite actions compartilhadas pela organização.
+
+## Composite Actions
+
+Diferente das reusable workflows abaixo (consumidas a nível de **job** via `uses:` no `jobs:`), composite actions são consumidas a nível de **step** dentro de um job existente.
+
+### Bucket Publish JAR ([bucket-publish-jar](./bucket-publish-jar))
+Publica um JAR em um ou mais buckets de Object Storage, gravando a versão como metadado. Implementação atual: OCI Object Storage. Interface provider-agnostic, preparada para futuras migrações de provedor.
+
+Ver [bucket-publish-jar/README.md](./bucket-publish-jar/README.md) para detalhes de uso, inputs e formato do secret `BUCKET_PUBLISH_CREDENTIALS`.
+
+---
+
+## Reusable Workflows
 
 ## Check Commit (check-commit.yml)
 Utilizada para verificar a quantidade de commits que houveram na branch main, desde a última tag/release criada

--- a/bucket-publish-jar/README.md
+++ b/bucket-publish-jar/README.md
@@ -1,0 +1,68 @@
+# bucket-publish-jar
+
+Publica um JAR em um ou mais buckets de Object Storage, gravando a versão como metadado. Implementação atual: **OCI Object Storage**.
+
+A interface da action é provider-agnostic — uma migração futura para outro provedor não exige mudança nos workflows consumidores, apenas no conteúdo do secret de credenciais e na implementação interna da action.
+
+> **Nota:** esta é uma _composite action_ (consumida a nível de **step** com `uses:`), diferente das _reusable workflows_ deste repositório que são consumidas a nível de **job**.
+
+## Uso
+
+```yaml
+- name: Publish JAR
+  uses: vrsoftbr/reusable-workflows/bucket-publish-jar@main
+  with:
+    credentials: ${{ secrets.BUCKET_PUBLISH_CREDENTIALS }}
+    file:        dist/MeuApp.jar
+    object-name: MeuApp.jar
+    buckets:     'vr_4_4 vr_releases'
+    version:     '4.4.79'
+```
+
+## Inputs
+
+| Input | Obrigatório | Descrição |
+|---|---|---|
+| `credentials` | sim | JSON com as credenciais do provedor. Veja [formato abaixo](#formato-do-secret-bucket_publish_credentials). |
+| `file` | sim | Caminho local do arquivo a publicar. |
+| `object-name` | sim | Nome do objeto no bucket. |
+| `buckets` | sim | Lista de buckets separada por espaço. |
+| `version` | sim | Versão a ser gravada como metadado `versao`. |
+
+## Formato do secret `BUCKET_PUBLISH_CREDENTIALS`
+
+JSON único contendo todos os campos. **Recomenda-se configurá-lo como Organization Secret** com visibilidade restrita aos repositórios privados:
+
+```json
+{
+  "user": "ocid1.user.oc1..xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+  "tenancy": "ocid1.tenancy.oc1..xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+  "fingerprint": "aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99",
+  "region": "sa-saopaulo-1",
+  "key_content_b64": "<base64 do PEM completo>"
+}
+```
+
+### Como gerar o `key_content_b64`
+
+A partir do arquivo PEM apontado em `key_file` do seu `~/.oci/config`:
+
+```powershell
+# Windows PowerShell
+[Convert]::ToBase64String([IO.File]::ReadAllBytes("$HOME\.oci\oci_api_key.pem"))
+```
+
+```bash
+# Linux/macOS
+base64 -w0 < ~/.oci/oci_api_key.pem
+```
+
+Cole a saída (linha única) no campo `key_content_b64`.
+
+## Metadados gravados
+
+Cada objeto recebe o metadado `versao` com o valor de `inputs.version`.
+
+Ao ler via API OCI, o header é `opc-meta-versao`.
+
+> **Nota de migração:** o pipeline anterior em GCS usava o header `x-goog-meta-versao`. Consumidores que liam esse header explicitamente precisam ser ajustados.

--- a/bucket-publish-jar/action.yml
+++ b/bucket-publish-jar/action.yml
@@ -21,27 +21,37 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Parse credentials and expose as env
+    - name: Setup OCI config from credentials
       shell: bash
       env:
         CREDS: ${{ inputs.credentials }}
       run: |
         set -euo pipefail
 
-        echo "OCI_CLI_USER=$(echo "$CREDS"        | jq -r .user)"        >> "$GITHUB_ENV"
-        echo "OCI_CLI_TENANCY=$(echo "$CREDS"     | jq -r .tenancy)"     >> "$GITHUB_ENV"
-        echo "OCI_CLI_FINGERPRINT=$(echo "$CREDS" | jq -r .fingerprint)" >> "$GITHUB_ENV"
-        echo "OCI_CLI_REGION=$(echo "$CREDS"      | jq -r .region)"      >> "$GITHUB_ENV"
+        mkdir -p "$HOME/.oci"
+        chmod 700 "$HOME/.oci"
 
-        KEY_PEM=$(echo "$CREDS" | jq -r .key_content_b64 | base64 -d)
-        {
-          echo 'OCI_CLI_KEY_CONTENT<<PEM_EOF'
-          echo "$KEY_PEM"
-          echo 'PEM_EOF'
-        } >> "$GITHUB_ENV"
+        echo "$CREDS" | jq -r .key_content_b64 | base64 -d > "$HOME/.oci/oci_api_key.pem"
+        chmod 600 "$HOME/.oci/oci_api_key.pem"
 
-    - name: Configure OCI CLI
-      uses: oracle-actions/configure-oci-cli@v1.3.1
+        OCI_USER=$(echo        "$CREDS" | jq -r .user)
+        OCI_TENANCY=$(echo     "$CREDS" | jq -r .tenancy)
+        OCI_FINGERPRINT=$(echo "$CREDS" | jq -r .fingerprint)
+        OCI_REGION=$(echo      "$CREDS" | jq -r .region)
+
+        cat > "$HOME/.oci/config" <<EOF
+        [DEFAULT]
+        user=$OCI_USER
+        tenancy=$OCI_TENANCY
+        fingerprint=$OCI_FINGERPRINT
+        region=$OCI_REGION
+        key_file=$HOME/.oci/oci_api_key.pem
+        EOF
+        chmod 600 "$HOME/.oci/config"
+
+    - name: Install OCI CLI
+      shell: bash
+      run: pipx install oci-cli
 
     - name: Upload to buckets
       shell: bash

--- a/bucket-publish-jar/action.yml
+++ b/bucket-publish-jar/action.yml
@@ -1,0 +1,67 @@
+name: 'Bucket Publish JAR'
+description: 'Publica um JAR em buckets de Object Storage com metadado de versão (implementação atual: OCI).'
+
+inputs:
+  credentials:
+    description: 'JSON com credenciais do provedor. Ver README para o formato.'
+    required: true
+  file:
+    description: 'Caminho local do arquivo a publicar.'
+    required: true
+  object-name:
+    description: 'Nome do objeto no bucket.'
+    required: true
+  buckets:
+    description: 'Lista de buckets separada por espaço (ex: "vr_4_4 vr_releases").'
+    required: true
+  version:
+    description: 'Versão a ser gravada como metadado `versao`.'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Parse credentials and expose as env
+      shell: bash
+      env:
+        CREDS: ${{ inputs.credentials }}
+      run: |
+        set -euo pipefail
+
+        echo "OCI_CLI_USER=$(echo "$CREDS"        | jq -r .user)"        >> "$GITHUB_ENV"
+        echo "OCI_CLI_TENANCY=$(echo "$CREDS"     | jq -r .tenancy)"     >> "$GITHUB_ENV"
+        echo "OCI_CLI_FINGERPRINT=$(echo "$CREDS" | jq -r .fingerprint)" >> "$GITHUB_ENV"
+        echo "OCI_CLI_REGION=$(echo "$CREDS"      | jq -r .region)"      >> "$GITHUB_ENV"
+
+        KEY_PEM=$(echo "$CREDS" | jq -r .key_content_b64 | base64 -d)
+        {
+          echo 'OCI_CLI_KEY_CONTENT<<PEM_EOF'
+          echo "$KEY_PEM"
+          echo 'PEM_EOF'
+        } >> "$GITHUB_ENV"
+
+    - name: Configure OCI CLI
+      uses: oracle-actions/configure-oci-cli@v1.3.1
+
+    - name: Upload to buckets
+      shell: bash
+      env:
+        FILE: ${{ inputs.file }}
+        OBJECT_NAME: ${{ inputs.object-name }}
+        BUCKETS: ${{ inputs.buckets }}
+        VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+
+        NAMESPACE=$(oci os ns get --query data --raw-output)
+
+        for BUCKET in $BUCKETS; do
+          oci os object put \
+            --namespace-name "$NAMESPACE" \
+            --bucket-name    "$BUCKET" \
+            --name           "$OBJECT_NAME" \
+            --file           "$FILE" \
+            --metadata       "{\"versao\":\"$VERSION\"}" \
+            --force
+          echo "✓ $OBJECT_NAME v$VERSION → $BUCKET"
+        done


### PR DESCRIPTION
Composite action para publicar JAR em buckets de Object Storage com metadado de versao. Implementacao atual: OCI Object Storage, mas a interface e provider-agnostic para facilitar futuras migracoes.

Requer Organization Secret BUCKET_PUBLISH_CREDENTIALS com as credenciais do provedor em formato JSON (ver bucket-publish-jar/README.md).