### PR TITLE
feat: adiciona workflow Claude PR Review

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -84,11 +84,25 @@ jobs:
           # cai pro GITHUB_TOKEN padrão se não. Expressão || requer Actions runner recente — OK em ubuntu-latest.
           token: ${{ secrets.POLICY_REPO_TOKEN || github.token }}
 
-      - name: Checkout scripts auxiliares (mesmo commit deste workflow)
+      - name: Resolver ref do reusable-workflows
+        id: wfref
+        # github.workflow_ref vem em "owner/repo/.github/workflows/file.yml@refs/heads/branch"
+        # (ou @refs/tags/vX). Strip da parte antes do @ pra ficar com a ref pura, que o
+        # actions/checkout aceita. Não usar github.workflow_sha — em reusable workflow chamado
+        # de outro repo via pull_request, ele retorna o merge commit sintético do PR, que
+        # não é fetchable como sha normal ("not our ref").
+        shell: bash
+        run: |
+          set -euo pipefail
+          REF="${GITHUB_WORKFLOW_REF##*@}"
+          echo "Ref resolvida: $REF"
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout scripts auxiliares (mesma ref deste workflow)
         uses: actions/checkout@v4
         with:
           repository: vrsoftbr/reusable-workflows
-          ref: ${{ github.workflow_sha }}
+          ref: ${{ steps.wfref.outputs.ref }}
           path: .reusable-workflows
 
       - name: Compor política de review (default + stack + projeto)

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -189,3 +189,46 @@ jobs:
             ## Saída
             Publique exatamente UM comentário consolidado no PR seguindo o formato definido na política.
             Não abra reviews de linha individuais.
+
+      - name: Verificar se review foi publicado
+        # Roda sempre — inclusive se step anterior "passou" silenciosamente.
+        # Detecta o caso "Claude skipou por workflow validation" e dá feedback visual
+        # claro no PR + check vermelho, em vez de tudo verde com warning escondido no log.
+        if: always()
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          # Pequena pausa pra garantir que comment, se houver, já propagou.
+          sleep 10
+
+          # Conta comments dos últimos 5 min vindos de bots (Claude / GitHub Actions / Apps).
+          HAS_BOT_COMMENT=$(gh pr view "$PR" --repo "$REPO" --json comments \
+            --jq '[.comments[]
+                    | select(.author.login | test("claude|github-actions|bot|app/"; "i"))
+                    | select((.createdAt | fromdateiso8601) > (now - 300))
+                  ] | length')
+
+          if [ "${HAS_BOT_COMMENT:-0}" -ge 1 ]; then
+            echo "Review foi publicado (encontrou $HAS_BOT_COMMENT comment(s) recente(s) de bot)."
+            exit 0
+          fi
+
+          echo "Nenhum comentário de bot detectado — Claude provavelmente skipou."
+
+          gh pr comment "$PR" --repo "$REPO" --body "⚠️ **Claude PR Review não publicou comentário nesta execução.**
+
+          A action terminou sem deixar review no PR. Causas comuns:
+
+          1. **Workflow validation** — o arquivo \`.github/workflows/pr-review.yml\` ainda não está na default branch do repo (ou está com conteúdo diferente). A \`anthropics/claude-code-action\` exige isso por segurança. **Solução:** mergeie o caller workflow na default branch uma vez; PRs subsequentes disparam normalmente.
+          2. **Quota Pro/Max esgotada** — janela de 5h consumida. Aguardar próxima janela.
+          3. **Erro de configuração** — credencial inválida, MCP config malformado, ou outro problema. Verifique a saída de cada step.
+
+          Logs desta execução: $RUN_URL"
+
+          # Falha o step pra deixar visível no status check do PR.
+          exit 1

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -84,94 +84,32 @@ jobs:
           # cai pro GITHUB_TOKEN padrão se não. Expressão || requer Actions runner recente — OK em ubuntu-latest.
           token: ${{ secrets.POLICY_REPO_TOKEN || github.token }}
 
+      - name: Checkout scripts auxiliares (mesmo commit deste workflow)
+        uses: actions/checkout@v4
+        with:
+          repository: vrsoftbr/reusable-workflows
+          ref: ${{ github.workflow_sha }}
+          path: .reusable-workflows
+
       - name: Compor política de review (default + stack + projeto)
         id: compose
         shell: bash
         env:
+          POLICY_DIR: .claude-review-policy
+          OUT_FILE: .claude/review-policy.md
           STACK: ${{ inputs.stack }}
           PROJECT: ${{ inputs.project }}
-        run: |
-          set -euo pipefail
-          mkdir -p .claude
-          OUT=.claude/review-policy.md
-
-          DEFAULT_FILE=.claude-review-policy/instructions/default.md
-          if [ ! -f "$DEFAULT_FILE" ]; then
-            echo "::error::Política padrão não encontrada em $DEFAULT_FILE — repo de policy correto? (${{ inputs.policy_repo }}@${{ inputs.policy_ref }})"
-            exit 1
-          fi
-
-          {
-            echo "# Política composta de code review"
-            echo ""
-            echo "Esta política foi composta em camadas. Camadas mais específicas (declaradas mais abaixo)"
-            echo "têm precedência sobre as mais gerais quando houver conflito explícito."
-            echo ""
-            echo "---"
-            echo ""
-            echo "## Camada 1 — Política padrão"
-            echo ""
-            cat "$DEFAULT_FILE"
-          } > "$OUT"
-
-          APPLIED="default"
-
-          if [ -n "$STACK" ]; then
-            STACK_FILE=".claude-review-policy/instructions/stacks/${STACK}.md"
-            if [ -f "$STACK_FILE" ]; then
-              {
-                echo ""
-                echo "---"
-                echo ""
-                echo "## Camada 2 — Stack: ${STACK}"
-                echo ""
-                cat "$STACK_FILE"
-              } >> "$OUT"
-              APPLIED="${APPLIED}, stack:${STACK}"
-            else
-              echo "::warning::Stack '${STACK}' declarada mas $STACK_FILE não existe — ignorada."
-            fi
-          fi
-
-          if [ -n "$PROJECT" ]; then
-            PROJECT_FILE=".claude-review-policy/instructions/projects/${PROJECT}.md"
-            if [ -f "$PROJECT_FILE" ]; then
-              {
-                echo ""
-                echo "---"
-                echo ""
-                echo "## Camada 3 — Projeto: ${PROJECT} (precedência máxima)"
-                echo ""
-                cat "$PROJECT_FILE"
-              } >> "$OUT"
-              APPLIED="${APPLIED}, projeto:${PROJECT}"
-            else
-              echo "::warning::Projeto '${PROJECT}' declarado mas $PROJECT_FILE não existe — ignorado."
-            fi
-          fi
-
-          echo "applied=${APPLIED}" >> "$GITHUB_OUTPUT"
-          echo "## Camadas aplicadas: ${APPLIED}"
-          echo "----- início da política composta -----"
-          cat "$OUT"
-          echo "----- fim da política composta -----"
+          POLICY_REPO: ${{ inputs.policy_repo }}
+          POLICY_REF: ${{ inputs.policy_ref }}
+        run: bash .reusable-workflows/.github/workflows/claude-review/compose-policy.sh
 
       - name: Extrair chave Jira do PR
         id: jira
         shell: bash
-        run: |
-          TITLE="${{ github.event.pull_request.title }}"
-          BRANCH="${{ github.event.pull_request.head.ref }}"
-          KEY=$(printf '%s %s' "$TITLE" "$BRANCH" | grep -oE '[A-Z][A-Z0-9]+-[0-9]+' | head -n1 || true)
-          if [ -n "$KEY" ]; then
-            echo "Chave detectada: $KEY"
-            echo "key=$KEY" >> "$GITHUB_OUTPUT"
-            echo "has_ticket=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "Nenhuma chave Jira encontrada em título/branch"
-            echo "key=" >> "$GITHUB_OUTPUT"
-            echo "has_ticket=false" >> "$GITHUB_OUTPUT"
-          fi
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+        run: bash .reusable-workflows/.github/workflows/claude-review/extract-jira-key.sh
 
       - name: Pré-pull da imagem do MCP do Atlassian
         run: docker pull ghcr.io/sooperset/mcp-atlassian:latest

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -163,8 +163,9 @@ jobs:
           show_full_output: true
           # API da action @v1 não aceita mais `mcp_config` e `allowed_tools` como inputs.
           # Em vez disso, passamos via `claude_args` (string repassada ao CLI subjacente).
+          # DEBUG: --model claude-opus-4-7 removido temporariamente pra isolar se o
+          # crash do SDK é causado pelo override de modelo + OAuth. Reintroduzir depois.
           claude_args: >-
-            --model claude-opus-4-7
             --mcp-config .claude/mcp.json
             --allowed-tools "mcp__atlassian__jira_get_issue,mcp__atlassian__jira_search,mcp__atlassian__jira_get_issue_comments,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Read,Grep,Glob"
           prompt: |

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -160,6 +160,7 @@ jobs:
           # API da action @v1 não aceita mais `mcp_config` e `allowed_tools` como inputs.
           # Em vez disso, passamos via `claude_args` (string repassada ao CLI subjacente).
           claude_args: >-
+            --model claude-opus-4-7
             --mcp-config .claude/mcp.json
             --allowed-tools "mcp__atlassian__jira_get_issue,mcp__atlassian__jira_search,mcp__atlassian__jira_get_issue_comments,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Read,Grep,Glob"
           prompt: |

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -157,6 +157,10 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # TEMPORÁRIO (debug): expõe a saída completa do SDK no log pra diagnosticar
+          # o "SDK execution error". REMOVER após identificar a causa — expõe output
+          # potencialmente sensível no log do CI.
+          show_full_output: true
           # API da action @v1 não aceita mais `mcp_config` e `allowed_tools` como inputs.
           # Em vez disso, passamos via `claude_args` (string repassada ao CLI subjacente).
           claude_args: >-

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -201,10 +201,27 @@ jobs:
           3. Use o conteúdo combinado como base da seção "Aderência ao ticket".
           Se NÃO houver chave, pule "Aderência ao ticket" e mencione no Resumo que não há ticket.
 
-          ## Saída (IMPORTANTE)
-          Produza UM comentário consolidado em markdown, seguindo o formato definido na política.
-          Sua saída INTEIRA será postada como comentário no PR — não inclua preâmbulo, saudação,
-          nem qualquer texto fora do comentário de review.
+          ## Saída (formato obrigatório — JSON)
+          Produza EXCLUSIVAMENTE um objeto JSON válido (sem cercas de código markdown, sem
+          texto antes ou depois). Estrutura exata:
+          {
+            "summary": "markdown com as seções: Resumo; Aderência ao ticket (omita se não houver ticket); Cobertura desta revisão; Veredito (use um de: pronto para merge / ajustes recomendados / bloqueado)",
+            "findings": [
+              {
+                "path": "caminho/relativo/do/arquivo/a/partir/da/raiz/do/repo",
+                "line": 123,
+                "severity": "ALTA",
+                "body": "markdown: o que está errado, por que é problema NESTE projeto, e a correção sugerida"
+              }
+            ]
+          }
+          Regras do JSON:
+          - "line" DEVE ser uma linha que aparece no diff deste PR (linha adicionada ou
+            modificada, lado novo). NUNCA cite linha fora do diff — a API do GitHub rejeita.
+          - "severity" é um de: "ALTA", "MEDIA", "BAIXA" (sem acento, pra evitar problema de encoding).
+          - As seções Bloqueios e Sugestões da política NÃO vão no summary — viram itens em "findings".
+          - Se não houver nenhum achado, "findings" deve ser [].
+          - Sua saída inteira deve ser parseável por jq. Nada de preâmbulo, saudação ou cercas.
           EOF
           echo "----- prompt montado -----"
           cat .claude/prompt.txt
@@ -220,20 +237,71 @@ jobs:
             --model claude-opus-4-7 \
             --mcp-config .claude/mcp.json \
             --allowed-tools "mcp__atlassian__jira_get_issue,mcp__atlassian__jira_search,mcp__atlassian__jira_get_issue_comments,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Read,Grep,Glob" \
-            > .claude/review-output.md
-          if [ ! -s .claude/review-output.md ]; then
+            > .claude/review-raw.txt
+          if [ ! -s .claude/review-raw.txt ]; then
             echo "::error::Review veio vazio — Claude não produziu saída."
             exit 1
           fi
-          echo "----- review gerado -----"
-          cat .claude/review-output.md
+          echo "----- saída crua do Claude -----"
+          cat .claude/review-raw.txt
+          # Remove cercas ```json / ``` caso o Claude as tenha adicionado; o resto deve ser o JSON.
+          sed -e 's/^```json[[:space:]]*$//' -e 's/^```[[:space:]]*$//' .claude/review-raw.txt > .claude/review.json
+          if jq empty .claude/review.json 2>/dev/null; then
+            echo "json_ok=true" >> "$GITHUB_OUTPUT"
+            echo "----- JSON válido -----"
+            jq '.' .claude/review.json
+          else
+            echo "json_ok=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Saída não é JSON válido — será postada como comentário simples (fallback)."
+          fi
 
-      - name: Postar review no PR
+      - name: Postar review no PR (resumo + inline)
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
           PR: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
+          JSON_OK: ${{ steps.review.outputs.json_ok }}
         run: |
           set -euo pipefail
-          gh pr comment "$PR" --repo "$REPO" --body-file .claude/review-output.md
+
+          # Fallback 1: saída não-JSON → posta crua como comentário simples.
+          if [ "$JSON_OK" != "true" ]; then
+            gh pr comment "$PR" --repo "$REPO" --body-file .claude/review-raw.txt
+            exit 0
+          fi
+
+          # Monta o payload da PR Review API: body = summary, comments = findings inline.
+          # event=COMMENT sempre (bot não pode aprovar/bloquear PR; veredito vai no texto).
+          jq '{
+            body: .summary,
+            event: "COMMENT",
+            comments: [
+              .findings[]
+              | { path: .path, line: .line, side: "RIGHT",
+                  body: ("**[" + .severity + "]** " + .body) }
+            ]
+          }' .claude/review.json > .claude/review-payload.json
+
+          NFIND=$(jq '.findings | length' .claude/review.json)
+          echo "Achados: $NFIND"
+
+          # Tenta postar review com comentários inline.
+          if gh api "repos/$REPO/pulls/$PR/reviews" --method POST \
+               --input .claude/review-payload.json >/dev/null 2>.claude/api-err.txt; then
+            echo "Review postado com $NFIND comentário(s) inline + resumo."
+            exit 0
+          fi
+
+          # Fallback 2: API rejeitou (ex.: linha fora do diff) → consolida tudo num comentário.
+          echo "::warning::PR Review API rejeitou os inline. Detalhe:"
+          cat .claude/api-err.txt || true
+          {
+            jq -r '.summary' .claude/review.json
+            echo ""
+            echo "---"
+            echo "_Não foi possível postar inline (alguma linha fora do diff). Achados consolidados:_"
+            jq -r '.findings[] | "\n**[" + .severity + "]** `" + .path + ":" + (.line|tostring) + "`\n\n" + .body' .claude/review.json
+          } > .claude/review-fallback.md
+          gh pr comment "$PR" --repo "$REPO" --body-file .claude/review-fallback.md
+          echo "Postado como comentário consolidado (fallback)."

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -84,25 +84,15 @@ jobs:
           # cai pro GITHUB_TOKEN padrão se não. Expressão || requer Actions runner recente — OK em ubuntu-latest.
           token: ${{ secrets.POLICY_REPO_TOKEN || github.token }}
 
-      - name: Resolver ref do reusable-workflows
-        id: wfref
-        # github.workflow_ref vem em "owner/repo/.github/workflows/file.yml@refs/heads/branch"
-        # (ou @refs/tags/vX). Strip da parte antes do @ pra ficar com a ref pura, que o
-        # actions/checkout aceita. Não usar github.workflow_sha — em reusable workflow chamado
-        # de outro repo via pull_request, ele retorna o merge commit sintético do PR, que
-        # não é fetchable como sha normal ("not our ref").
-        shell: bash
-        run: |
-          set -euo pipefail
-          REF="${GITHUB_WORKFLOW_REF##*@}"
-          echo "Ref resolvida: $REF"
-          echo "ref=$REF" >> "$GITHUB_OUTPUT"
-
-      - name: Checkout scripts auxiliares (mesma ref deste workflow)
+      - name: Checkout scripts auxiliares
         uses: actions/checkout@v4
         with:
           repository: vrsoftbr/reusable-workflows
-          ref: ${{ steps.wfref.outputs.ref }}
+          # TODO: trocar para `main` após esta PR (#3) ser mergeada.
+          # Mantemos hardcoded enquanto branch de teste — github.workflow_sha retorna
+          # merge commit sintético do PR (não fetchable), e workflow_ref exige parsing
+          # extra; pra fase de testes, hardcode é mais simples.
+          ref: feat/claude-pr-review
           path: .reusable-workflows
 
       - name: Compor política de review (default + stack + projeto)

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -153,87 +153,87 @@ jobs:
           }
           EOF
 
-      - name: Executar review com Claude
-        uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # TEMPORÁRIO (debug): expõe a saída completa do SDK no log pra diagnosticar
-          # o "SDK execution error". REMOVER após identificar a causa — expõe output
-          # potencialmente sensível no log do CI.
-          show_full_output: true
-          # API da action @v1 não aceita mais `mcp_config` e `allowed_tools` como inputs.
-          # Em vez disso, passamos via `claude_args` (string repassada ao CLI subjacente).
-          # DEBUG: --model claude-opus-4-7 removido temporariamente pra isolar se o
-          # crash do SDK é causado pelo override de modelo + OAuth. Reintroduzir depois.
-          claude_args: >-
-            --mcp-config .claude/mcp.json
-            --allowed-tools "mcp__atlassian__jira_get_issue,mcp__atlassian__jira_search,mcp__atlassian__jira_get_issue_comments,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Read,Grep,Glob"
-          prompt: |
-            Você é o revisor automático deste pull request.
+      # A action anthropics/claude-code-action@v1 tem bug aberto (#676, #872, #1316)
+      # que limpa o CLAUDE_CODE_OAUTH_TOKEN antes da execução do SDK, quebrando auth
+      # OAuth. O CLI `claude` lê o token do env sem esse bug. Por isso chamamos o CLI
+      # direto em vez de usar a action.
 
-            ## Instruções obrigatórias
-            Leia e siga RIGOROSAMENTE o arquivo `.claude/review-policy.md`.
-            Esse arquivo é uma política em camadas (default + stack + projeto, quando aplicáveis).
-            Camadas mais específicas têm precedência sobre as mais gerais quando houver conflito.
+      - name: Instalar Claude CLI
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm install -g @anthropic-ai/claude-code
+          claude --version
 
-            Camadas aplicadas neste review: ${{ steps.compose.outputs.applied }}.
+      - name: Montar prompt do review
+        shell: bash
+        env:
+          APPLIED: ${{ steps.compose.outputs.applied }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          TICKET_CONTEXT: "${{ steps.jira.outputs.has_ticket == 'true' && format('Chave Jira detectada no titulo/branch: {0}. Use o MCP do Jira para buscar o contexto deste ticket.', steps.jira.outputs.key) || 'Nenhuma chave Jira detectada no titulo nem na branch deste PR.' }}"
+        run: |
+          set -euo pipefail
+          mkdir -p .claude
+          # Heredoc sem aspas para interpolar as env vars. Prompt evita backticks de
+          # propósito (backtick em heredoc não-aspas viraria command substitution).
+          cat > .claude/prompt.txt <<EOF
+          Você é o revisor automático deste pull request.
 
-            ## Contexto do ticket
+          ## Instruções obrigatórias
+          Leia e siga RIGOROSAMENTE o arquivo .claude/review-policy.md (já está no diretório atual).
+          É uma política em camadas (default + stack + projeto). Camadas mais específicas têm
+          precedência sobre as mais gerais quando houver conflito.
 
-            ${{ steps.jira.outputs.has_ticket == 'true' && format('Chave Jira detectada no título/branch: **{0}**.', steps.jira.outputs.key) || 'Nenhuma chave Jira detectada no título nem na branch deste PR.' }}
+          Camadas aplicadas neste review: ${APPLIED}.
 
-            ### Como buscar contexto do ticket
+          ## O que revisar
+          As mudanças deste PR estão no diff entre origin/${BASE_REF} e HEAD.
+          Rode: git diff origin/${BASE_REF}...HEAD para ver as mudanças (a tool Bash(git diff:*) está liberada).
+          Para avaliar impacto, use Grep/Glob/Read para investigar callers e arquivos relacionados.
 
-            - **Se houver chave Jira detectada acima** — ANTES de qualquer análise do diff:
-              1. Chame `mcp__atlassian__jira_get_issue` com a chave detectada.
-              2. Inspecione o resultado. Se o ticket for sub-task (campo `issuetype.subtask == true` OU campo `parent` preenchido), chame `mcp__atlassian__jira_get_issue` também na chave do parent — o escopo de negócio costuma viver lá. NÃO suba mais de um nível (sub-task → parent é suficiente; não persiga story → epic).
-              3. Use o conteúdo combinado (sub-task + parent quando aplicável) como base da seção "Aderência ao ticket" do comentário final. Cite qual ticket forneceu o escopo principal.
+          ## Contexto do ticket
+          ${TICKET_CONTEXT}
 
-            - **Se NÃO houver chave Jira detectada** — pule a seção "Aderência ao ticket" no comentário final e mencione explicitamente no Resumo que não há ticket associado a este PR.
+          Se houver chave Jira acima, ANTES de analisar o diff:
+          1. Chame mcp__atlassian__jira_get_issue com a chave.
+          2. Se o ticket for sub-task (issuetype.subtask == true ou campo parent preenchido),
+             chame mcp__atlassian__jira_get_issue também no parent. NÃO suba mais de um nível.
+          3. Use o conteúdo combinado como base da seção "Aderência ao ticket".
+          Se NÃO houver chave, pule "Aderência ao ticket" e mencione no Resumo que não há ticket.
 
-            ## Saída
-            Publique exatamente UM comentário consolidado no PR seguindo o formato definido na política.
-            Não abra reviews de linha individuais.
+          ## Saída (IMPORTANTE)
+          Produza UM comentário consolidado em markdown, seguindo o formato definido na política.
+          Sua saída INTEIRA será postada como comentário no PR — não inclua preâmbulo, saudação,
+          nem qualquer texto fora do comentário de review.
+          EOF
+          echo "----- prompt montado -----"
+          cat .claude/prompt.txt
 
-      - name: Verificar se review foi publicado
-        # Roda sempre — inclusive se step anterior "passou" silenciosamente.
-        # Detecta o caso "Claude skipou por workflow validation" e dá feedback visual
-        # claro no PR + check vermelho, em vez de tudo verde com warning escondido no log.
-        if: always()
+      - name: Rodar review (Claude CLI direto)
+        id: review
+        shell: bash
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          set -euo pipefail
+          claude -p "$(cat .claude/prompt.txt)" \
+            --model claude-opus-4-7 \
+            --mcp-config .claude/mcp.json \
+            --allowed-tools "mcp__atlassian__jira_get_issue,mcp__atlassian__jira_search,mcp__atlassian__jira_get_issue_comments,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Read,Grep,Glob" \
+            > .claude/review-output.md
+          if [ ! -s .claude/review-output.md ]; then
+            echo "::error::Review veio vazio — Claude não produziu saída."
+            exit 1
+          fi
+          echo "----- review gerado -----"
+          cat .claude/review-output.md
+
+      - name: Postar review no PR
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
           PR: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
-          # Pequena pausa pra garantir que comment, se houver, já propagou.
-          sleep 10
-
-          # Conta comments dos últimos 5 min vindos de bots (Claude / GitHub Actions / Apps).
-          HAS_BOT_COMMENT=$(gh pr view "$PR" --repo "$REPO" --json comments \
-            --jq '[.comments[]
-                    | select(.author.login | test("claude|github-actions|bot|app/"; "i"))
-                    | select((.createdAt | fromdateiso8601) > (now - 300))
-                  ] | length')
-
-          if [ "${HAS_BOT_COMMENT:-0}" -ge 1 ]; then
-            echo "Review foi publicado (encontrou $HAS_BOT_COMMENT comment(s) recente(s) de bot)."
-            exit 0
-          fi
-
-          echo "Nenhum comentário de bot detectado — Claude provavelmente skipou."
-
-          gh pr comment "$PR" --repo "$REPO" --body "⚠️ **Claude PR Review não publicou comentário nesta execução.**
-
-          A action terminou sem deixar review no PR. Causas comuns:
-
-          1. **Workflow validation** — o arquivo \`.github/workflows/pr-review.yml\` ainda não está na default branch do repo (ou está com conteúdo diferente). A \`anthropics/claude-code-action\` exige isso por segurança. **Solução:** mergeie o caller workflow na default branch uma vez; PRs subsequentes disparam normalmente.
-          2. **Quota Pro/Max esgotada** — janela de 5h consumida. Aguardar próxima janela.
-          3. **Erro de configuração** — credencial inválida, MCP config malformado, ou outro problema. Verifique a saída de cada step.
-
-          Logs desta execução: $RUN_URL"
-
-          # Falha o step pra deixar visível no status check do PR.
-          exit 1
+          gh pr comment "$PR" --repo "$REPO" --body-file .claude/review-output.md

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,223 @@
+name: Claude PR Review (reusable)
+
+# Reusable workflow centralizada — vive em vrsoftbr/reusable-workflows.
+# A POLÍTICA de review fica em outro repo (default: vrsoftbr/VRCodeReviewPolicy).
+# Cada projeto chama este workflow via `uses:` (veja exemplo no README.md).
+#
+# Política aplicada é composta em três camadas (na ordem), TODAS vivendo no repo de policy:
+#   1. default   — sempre aplicada (instructions/default.md)
+#   2. stack     — opcional, via input `stack` (instructions/stacks/<stack>.md)
+#   3. projeto   — opcional, via input `project` (instructions/projects/<project>.md)
+#
+# Camadas mais específicas têm precedência. Tudo é concatenado e passado ao Claude
+# como `.claude/review-policy.md`. Mudar a política não exige tocar em projeto algum —
+# basta alterar o repo de policy.
+#
+# Secrets necessários (idealmente a nível de organização):
+#   CLAUDE_CODE_OAUTH_TOKEN  -> gerado rodando `claude setup-token` localmente
+#   JIRA_USERNAME            -> e-mail da conta Atlassian
+#   JIRA_API_TOKEN           -> token criado em id.atlassian.com/manage-profile/security/api-tokens
+#   POLICY_REPO_TOKEN        -> OPCIONAL. Só necessário se o repo de policy for PRIVADO e
+#                               estiver em outro org/visibilidade do que o projeto que chama.
+#                               PAT fine-grained ou token de GitHub App com acesso read ao repo de policy.
+#                               Se omitido, o checkout usa o GITHUB_TOKEN padrão (funciona para repo público
+#                               ou se o repo de policy estiver no mesmo escopo com acesso liberado em Actions settings).
+
+on:
+  workflow_call:
+    inputs:
+      jira_url:
+        description: "URL base do Jira (ex: https://vrsoft.atlassian.net)"
+        required: true
+        type: string
+      stack:
+        description: "Nome da camada de stack a aplicar (ex: java, node-ts). Procura instructions/stacks/<stack>.md no repo de policy. Vazio = só default."
+        required: false
+        type: string
+        default: ""
+      project:
+        description: "ID do projeto. Resolve para instructions/projects/<project>.md no repo de policy. Vazio = sem camada de projeto."
+        required: false
+        type: string
+        default: ""
+      policy_ref:
+        description: "Ref do repo de policy (tag/branch/sha) — fixe em tag pra controlar mudanças"
+        required: false
+        type: string
+        default: main
+      policy_repo:
+        description: "owner/repo do repositório de policy"
+        required: false
+        type: string
+        default: vrsoftbr/VRCodeReviewPolicy
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN:
+        required: true
+      JIRA_USERNAME:
+        required: true
+      JIRA_API_TOKEN:
+        required: true
+      POLICY_REPO_TOKEN:
+        required: false
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Checkout PR (repo do projeto)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Checkout repo de policy
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.policy_repo }}
+          ref: ${{ inputs.policy_ref }}
+          path: .claude-review-policy
+          # Usa POLICY_REPO_TOKEN se fornecido (necessário pra repo privado em outro escopo);
+          # cai pro GITHUB_TOKEN padrão se não. Expressão || requer Actions runner recente — OK em ubuntu-latest.
+          token: ${{ secrets.POLICY_REPO_TOKEN || github.token }}
+
+      - name: Compor política de review (default + stack + projeto)
+        id: compose
+        shell: bash
+        env:
+          STACK: ${{ inputs.stack }}
+          PROJECT: ${{ inputs.project }}
+        run: |
+          set -euo pipefail
+          mkdir -p .claude
+          OUT=.claude/review-policy.md
+
+          DEFAULT_FILE=.claude-review-policy/instructions/default.md
+          if [ ! -f "$DEFAULT_FILE" ]; then
+            echo "::error::Política padrão não encontrada em $DEFAULT_FILE — repo de policy correto? (${{ inputs.policy_repo }}@${{ inputs.policy_ref }})"
+            exit 1
+          fi
+
+          {
+            echo "# Política composta de code review"
+            echo ""
+            echo "Esta política foi composta em camadas. Camadas mais específicas (declaradas mais abaixo)"
+            echo "têm precedência sobre as mais gerais quando houver conflito explícito."
+            echo ""
+            echo "---"
+            echo ""
+            echo "## Camada 1 — Política padrão"
+            echo ""
+            cat "$DEFAULT_FILE"
+          } > "$OUT"
+
+          APPLIED="default"
+
+          if [ -n "$STACK" ]; then
+            STACK_FILE=".claude-review-policy/instructions/stacks/${STACK}.md"
+            if [ -f "$STACK_FILE" ]; then
+              {
+                echo ""
+                echo "---"
+                echo ""
+                echo "## Camada 2 — Stack: ${STACK}"
+                echo ""
+                cat "$STACK_FILE"
+              } >> "$OUT"
+              APPLIED="${APPLIED}, stack:${STACK}"
+            else
+              echo "::warning::Stack '${STACK}' declarada mas $STACK_FILE não existe — ignorada."
+            fi
+          fi
+
+          if [ -n "$PROJECT" ]; then
+            PROJECT_FILE=".claude-review-policy/instructions/projects/${PROJECT}.md"
+            if [ -f "$PROJECT_FILE" ]; then
+              {
+                echo ""
+                echo "---"
+                echo ""
+                echo "## Camada 3 — Projeto: ${PROJECT} (precedência máxima)"
+                echo ""
+                cat "$PROJECT_FILE"
+              } >> "$OUT"
+              APPLIED="${APPLIED}, projeto:${PROJECT}"
+            else
+              echo "::warning::Projeto '${PROJECT}' declarado mas $PROJECT_FILE não existe — ignorado."
+            fi
+          fi
+
+          echo "applied=${APPLIED}" >> "$GITHUB_OUTPUT"
+          echo "## Camadas aplicadas: ${APPLIED}"
+          echo "----- início da política composta -----"
+          cat "$OUT"
+          echo "----- fim da política composta -----"
+
+      - name: Extrair chave Jira do PR
+        id: jira
+        shell: bash
+        run: |
+          TITLE="${{ github.event.pull_request.title }}"
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          KEY=$(printf '%s %s' "$TITLE" "$BRANCH" | grep -oE '[A-Z][A-Z0-9]+-[0-9]+' | head -n1 || true)
+          if [ -n "$KEY" ]; then
+            echo "Chave detectada: $KEY"
+            echo "key=$KEY" >> "$GITHUB_OUTPUT"
+            echo "has_ticket=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Nenhuma chave Jira encontrada em título/branch"
+            echo "key=" >> "$GITHUB_OUTPUT"
+            echo "has_ticket=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Pré-pull da imagem do MCP do Atlassian
+        run: docker pull ghcr.io/sooperset/mcp-atlassian:latest
+
+      - name: Executar review com Claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          mcp_config: |
+            {
+              "mcpServers": {
+                "atlassian": {
+                  "command": "docker",
+                  "args": [
+                    "run", "-i", "--rm",
+                    "-e", "JIRA_URL",
+                    "-e", "JIRA_USERNAME",
+                    "-e", "JIRA_API_TOKEN",
+                    "-e", "READ_ONLY_MODE=true",
+                    "-e", "ENABLED_TOOLS=jira_get_issue,jira_search,jira_get_issue_comments,jira_get_project_issues",
+                    "ghcr.io/sooperset/mcp-atlassian:latest"
+                  ],
+                  "env": {
+                    "JIRA_URL": "${{ inputs.jira_url }}",
+                    "JIRA_USERNAME": "${{ secrets.JIRA_USERNAME }}",
+                    "JIRA_API_TOKEN": "${{ secrets.JIRA_API_TOKEN }}"
+                  }
+                }
+              }
+            }
+          allowed_tools: "mcp__atlassian__jira_get_issue,mcp__atlassian__jira_search,mcp__atlassian__jira_get_issue_comments,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Read,Grep,Glob"
+          prompt: |
+            Você é o revisor automático deste pull request.
+
+            ## Instruções obrigatórias
+            Leia e siga RIGOROSAMENTE o arquivo `.claude/review-policy.md`.
+            Esse arquivo é uma política em camadas (default + stack + projeto, quando aplicáveis).
+            Camadas mais específicas têm precedência sobre as mais gerais quando houver conflito.
+
+            Camadas aplicadas neste review: ${{ steps.compose.outputs.applied }}.
+
+            ## Contexto do ticket
+            ${{ steps.jira.outputs.has_ticket == 'true'
+                && format('Ticket Jira: **{0}**. ANTES de revisar, chame `mcp__atlassian__jira_get_issue` com esta chave para entender o que foi pedido. Compare a entrega com o requisito do ticket na seção "Aderência ao ticket".', steps.jira.outputs.key)
+                || 'Não foi detectada chave Jira no título nem na branch do PR. Pule a seção "Aderência ao ticket" e mencione explicitamente no resumo que não há ticket associado.' }}
+
+            ## Saída
+            Publique exatamente UM comentário consolidado no PR seguindo o formato definido na política.
+            Não abra reviews de linha individuais.

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -214,9 +214,17 @@ jobs:
             Camadas aplicadas neste review: ${{ steps.compose.outputs.applied }}.
 
             ## Contexto do ticket
-            ${{ steps.jira.outputs.has_ticket == 'true'
-                && format('Ticket Jira: **{0}**. ANTES de revisar, chame `mcp__atlassian__jira_get_issue` com esta chave para entender o que foi pedido. Compare a entrega com o requisito do ticket na seção "Aderência ao ticket".', steps.jira.outputs.key)
-                || 'Não foi detectada chave Jira no título nem na branch do PR. Pule a seção "Aderência ao ticket" e mencione explicitamente no resumo que não há ticket associado.' }}
+
+            ${{ steps.jira.outputs.has_ticket == 'true' && format('Chave Jira detectada no título/branch: **{0}**.', steps.jira.outputs.key) || 'Nenhuma chave Jira detectada no título nem na branch deste PR.' }}
+
+            ### Como buscar contexto do ticket
+
+            - **Se houver chave Jira detectada acima** — ANTES de qualquer análise do diff:
+              1. Chame `mcp__atlassian__jira_get_issue` com a chave detectada.
+              2. Inspecione o resultado. Se o ticket for sub-task (campo `issuetype.subtask == true` OU campo `parent` preenchido), chame `mcp__atlassian__jira_get_issue` também na chave do parent — o escopo de negócio costuma viver lá. NÃO suba mais de um nível (sub-task → parent é suficiente; não persiga story → epic).
+              3. Use o conteúdo combinado (sub-task + parent quando aplicável) como base da seção "Aderência ao ticket" do comentário final. Cite qual ticket forneceu o escopo principal.
+
+            - **Se NÃO houver chave Jira detectada** — pule a seção "Aderência ao ticket" no comentário final e mencione explicitamente no Resumo que não há ticket associado a este PR.
 
             ## Saída
             Publique exatamente UM comentário consolidado no PR seguindo o formato definido na política.

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -118,33 +118,50 @@ jobs:
       - name: Pré-pull da imagem do MCP do Atlassian
         run: docker pull ghcr.io/sooperset/mcp-atlassian:latest
 
+      - name: Preparar MCP config (Jira)
+        shell: bash
+        env:
+          JIRA_URL: ${{ inputs.jira_url }}
+          JIRA_USERNAME: ${{ secrets.JIRA_USERNAME }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          mkdir -p .claude
+          # Aqui-doc interpola env vars no JSON. Valores com aspa dupla quebrariam o JSON —
+          # admin do org é responsável por usar tokens/usernames sem chars especiais.
+          cat > .claude/mcp.json <<EOF
+          {
+            "mcpServers": {
+              "atlassian": {
+                "command": "docker",
+                "args": [
+                  "run", "-i", "--rm",
+                  "-e", "JIRA_URL",
+                  "-e", "JIRA_USERNAME",
+                  "-e", "JIRA_API_TOKEN",
+                  "-e", "READ_ONLY_MODE=true",
+                  "-e", "ENABLED_TOOLS=jira_get_issue,jira_search,jira_get_issue_comments,jira_get_project_issues",
+                  "ghcr.io/sooperset/mcp-atlassian:latest"
+                ],
+                "env": {
+                  "JIRA_URL": "$JIRA_URL",
+                  "JIRA_USERNAME": "$JIRA_USERNAME",
+                  "JIRA_API_TOKEN": "$JIRA_API_TOKEN"
+                }
+              }
+            }
+          }
+          EOF
+
       - name: Executar review com Claude
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          mcp_config: |
-            {
-              "mcpServers": {
-                "atlassian": {
-                  "command": "docker",
-                  "args": [
-                    "run", "-i", "--rm",
-                    "-e", "JIRA_URL",
-                    "-e", "JIRA_USERNAME",
-                    "-e", "JIRA_API_TOKEN",
-                    "-e", "READ_ONLY_MODE=true",
-                    "-e", "ENABLED_TOOLS=jira_get_issue,jira_search,jira_get_issue_comments,jira_get_project_issues",
-                    "ghcr.io/sooperset/mcp-atlassian:latest"
-                  ],
-                  "env": {
-                    "JIRA_URL": "${{ inputs.jira_url }}",
-                    "JIRA_USERNAME": "${{ secrets.JIRA_USERNAME }}",
-                    "JIRA_API_TOKEN": "${{ secrets.JIRA_API_TOKEN }}"
-                  }
-                }
-              }
-            }
-          allowed_tools: "mcp__atlassian__jira_get_issue,mcp__atlassian__jira_search,mcp__atlassian__jira_get_issue_comments,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Read,Grep,Glob"
+          # API da action @v1 não aceita mais `mcp_config` e `allowed_tools` como inputs.
+          # Em vez disso, passamos via `claude_args` (string repassada ao CLI subjacente).
+          claude_args: >-
+            --mcp-config .claude/mcp.json
+            --allowed-tools "mcp__atlassian__jira_get_issue,mcp__atlassian__jira_search,mcp__atlassian__jira_get_issue_comments,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Read,Grep,Glob"
           prompt: |
             Você é o revisor automático deste pull request.
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -221,7 +221,9 @@ jobs:
           - "severity" é um de: "ALTA", "MEDIA", "BAIXA" (sem acento, pra evitar problema de encoding).
           - As seções Bloqueios e Sugestões da política NÃO vão no summary — viram itens em "findings".
           - Se não houver nenhum achado, "findings" deve ser [].
-          - Sua saída inteira deve ser parseável por jq. Nada de preâmbulo, saudação ou cercas.
+          - O PRIMEIRO caractere da sua resposta deve ser { e o ÚLTIMO deve ser }.
+            NÃO escreva nada antes do { (nem "Vou produzir o review", nem análise, nem
+            raciocínio) e nada depois do }. Sem cercas de código, sem saudação.
           EOF
           echo "----- prompt montado -----"
           cat .claude/prompt.txt
@@ -244,8 +246,9 @@ jobs:
           fi
           echo "----- saída crua do Claude -----"
           cat .claude/review-raw.txt
-          # Remove cercas ```json / ``` caso o Claude as tenha adicionado; o resto deve ser o JSON.
-          sed -e 's/^```json[[:space:]]*$//' -e 's/^```[[:space:]]*$//' .claude/review-raw.txt > .claude/review.json
+          # Claude às vezes adiciona preâmbulo ("Vou produzir o review.") e/ou cercas ```.
+          # Extrai do primeiro '{' ao último '}' pra isolar o objeto JSON.
+          python3 -c "s=open('.claude/review-raw.txt',encoding='utf-8').read(); i=s.find('{'); j=s.rfind('}'); open('.claude/review.json','w',encoding='utf-8').write(s[i:j+1] if (i>=0 and j>i) else '')"
           if jq empty .claude/review.json 2>/dev/null; then
             echo "json_ok=true" >> "$GITHUB_OUTPUT"
             echo "----- JSON válido -----"

--- a/.github/workflows/claude-review/compose-policy.sh
+++ b/.github/workflows/claude-review/compose-policy.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Compõe o arquivo de política de review em camadas (default + stack opcional + projeto opcional)
+# a partir do checkout do repo de policy.
+#
+# Env vars obrigatórias:
+#   POLICY_DIR   - caminho do checkout do repo de policy (ex.: .claude-review-policy)
+#   OUT_FILE     - arquivo de saída (ex.: .claude/review-policy.md)
+#   POLICY_REPO  - "owner/repo" do repo de policy, usado em mensagens de erro
+#   POLICY_REF   - ref (tag/branch/sha) do repo de policy, usado em mensagens de erro
+#   GITHUB_OUTPUT - injetado pelo runner do GitHub Actions
+#
+# Env vars opcionais:
+#   STACK        - id da stack; carrega instructions/stacks/$STACK.md
+#   PROJECT      - id do projeto; carrega instructions/projects/$PROJECT.md
+#
+# Outputs:
+#   Escreve o conteúdo composto em $OUT_FILE.
+#   Anexa `applied=<camadas separadas por vírgula>` ao $GITHUB_OUTPUT.
+
+set -euo pipefail
+
+: "${POLICY_DIR:?POLICY_DIR is required}"
+: "${OUT_FILE:?OUT_FILE is required}"
+: "${POLICY_REPO:?POLICY_REPO is required}"
+: "${POLICY_REF:?POLICY_REF is required}"
+: "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+STACK="${STACK:-}"
+PROJECT="${PROJECT:-}"
+
+mkdir -p "$(dirname "$OUT_FILE")"
+
+DEFAULT_FILE="$POLICY_DIR/instructions/default.md"
+if [ ! -f "$DEFAULT_FILE" ]; then
+  echo "::error::Política padrão não encontrada em $DEFAULT_FILE — repo de policy correto? (${POLICY_REPO}@${POLICY_REF})"
+  exit 1
+fi
+
+{
+  echo "# Política composta de code review"
+  echo ""
+  echo "Esta política foi composta em camadas. Camadas mais específicas (declaradas mais abaixo)"
+  echo "têm precedência sobre as mais gerais quando houver conflito explícito."
+  echo ""
+  echo "---"
+  echo ""
+  echo "## Camada 1 — Política padrão"
+  echo ""
+  cat "$DEFAULT_FILE"
+} > "$OUT_FILE"
+
+APPLIED="default"
+
+if [ -n "$STACK" ]; then
+  STACK_FILE="$POLICY_DIR/instructions/stacks/${STACK}.md"
+  if [ -f "$STACK_FILE" ]; then
+    {
+      echo ""
+      echo "---"
+      echo ""
+      echo "## Camada 2 — Stack: ${STACK}"
+      echo ""
+      cat "$STACK_FILE"
+    } >> "$OUT_FILE"
+    APPLIED="${APPLIED}, stack:${STACK}"
+  else
+    echo "::warning::Stack '${STACK}' declarada mas $STACK_FILE não existe — ignorada."
+  fi
+fi
+
+if [ -n "$PROJECT" ]; then
+  PROJECT_FILE="$POLICY_DIR/instructions/projects/${PROJECT}.md"
+  if [ -f "$PROJECT_FILE" ]; then
+    {
+      echo ""
+      echo "---"
+      echo ""
+      echo "## Camada 3 — Projeto: ${PROJECT} (precedência máxima)"
+      echo ""
+      cat "$PROJECT_FILE"
+    } >> "$OUT_FILE"
+    APPLIED="${APPLIED}, projeto:${PROJECT}"
+  else
+    echo "::warning::Projeto '${PROJECT}' declarado mas $PROJECT_FILE não existe — ignorado."
+  fi
+fi
+
+echo "applied=${APPLIED}" >> "$GITHUB_OUTPUT"
+echo "## Camadas aplicadas: ${APPLIED}"
+echo "----- início da política composta -----"
+cat "$OUT_FILE"
+echo "----- fim da política composta -----"

--- a/.github/workflows/claude-review/extract-jira-key.sh
+++ b/.github/workflows/claude-review/extract-jira-key.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Extrai chave Jira (padrão [A-Z][A-Z0-9]+-[0-9]+, ex.: PPV-123, ARQ-198)
+# do título e da branch do PR. Pega o primeiro match.
+#
+# Env vars obrigatórias:
+#   PR_TITLE        - título do PR (geralmente github.event.pull_request.title)
+#   PR_BRANCH       - branch head do PR (geralmente github.event.pull_request.head.ref)
+#   GITHUB_OUTPUT   - injetado pelo runner do GitHub Actions
+#
+# Recebe título/branch via env var (não interpolados direto no script) para evitar
+# injection caso título contenha caracteres especiais ($, `, ;, etc.).
+#
+# Outputs anexados ao $GITHUB_OUTPUT:
+#   key         - chave detectada (vazio se nenhuma)
+#   has_ticket  - "true" se detectada, "false" caso contrário
+
+set -euo pipefail
+
+: "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+PR_TITLE="${PR_TITLE:-}"
+PR_BRANCH="${PR_BRANCH:-}"
+
+KEY=$(printf '%s %s' "$PR_TITLE" "$PR_BRANCH" | grep -oE '[A-Z][A-Z0-9]+-[0-9]+' | head -n1 || true)
+
+if [ -n "$KEY" ]; then
+  echo "Chave Jira detectada: $KEY"
+  echo "key=$KEY" >> "$GITHUB_OUTPUT"
+  echo "has_ticket=true" >> "$GITHUB_OUTPUT"
+else
+  echo "Nenhuma chave Jira encontrada no título/branch."
+  echo "key=" >> "$GITHUB_OUTPUT"
+  echo "has_ticket=false" >> "$GITHUB_OUTPUT"
+fi

--- a/README.md
+++ b/README.md
@@ -124,4 +124,52 @@ jobs:
 ...
 ```
 
+## Claude PR Review (claude-review.yml)
+Executa code review automático em PRs usando o Claude (via plano OAuth, sem API key). Carrega contexto do ticket no Jira via MCP e aplica uma política em camadas mantida em outro repositório ([VRCodeReviewPolicy](https://github.com/vrsoftbr/VRCodeReviewPolicy)).
+
+Política aplicada (concatenada e passada ao Claude como prompt do review), na ordem:
+  1. **default** — `instructions/default.md` no repo de policy, sempre aplicada;
+  2. **stack** — `instructions/stacks/<stack>.md`, opcional, escolhida via input `stack`;
+  3. **projeto** — `instructions/projects/<project>.md`, opcional, escolhida via input `project`.
+
+Camadas mais específicas têm precedência. Como toda policy vive no repo central, alterar regras de qualquer projeto não exige tocar no repo do projeto.
+
+### Inputs:
+
+- `jira_url` URL base do Jira (ex.: `https://vrsoft.atlassian.net`) **[obrigatório]**
+- `stack` nome da camada de stack (resolve para `instructions/stacks/<stack>.md`). Vazio = só default
+- `project` ID do projeto (resolve para `instructions/projects/<project>.md`). Vazio = sem camada de projeto
+- `policy_ref` ref do repo de policy (tag/branch/sha). Default: `main`. Recomenda-se fixar em tag (`v1`)
+- `policy_repo` `owner/repo` do repositório de policy. Default: `vrsoftbr/VRCodeReviewPolicy`
+
+### Secrets:
+
+- `CLAUDE_CODE_OAUTH_TOKEN` token OAuth gerado por `claude setup-token` localmente **[obrigatório]**
+- `JIRA_USERNAME` e-mail da conta Atlassian **[obrigatório]**
+- `JIRA_API_TOKEN` API token criado em `id.atlassian.com/manage-profile/security/api-tokens` **[obrigatório]**
+- `POLICY_REPO_TOKEN` PAT/App token com acesso read ao repo de policy. **Opcional** — necessário apenas se o repo de policy for privado e o `GITHUB_TOKEN` padrão não tiver acesso
+
+### Exemplo
+```
+name: Code review (Claude)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    uses: vrsoftbr/reusable-workflows/.github/workflows/claude-review.yml@main
+    with:
+      jira_url: https://vrsoft.atlassian.net
+      stack: java
+      project: vrpdv
+      policy_ref: v1
+    secrets: inherit
+```
+
 


### PR DESCRIPTION
## Resumo

Adiciona um novo reusable workflow ao repositório: **Claude PR Review** (`claude-review.yml`). Executa code review automático em PRs usando o Claude via plano OAuth (sem API key), com contexto do ticket no Jira via MCP e política em camadas vinda do repo central [vrsoftbr/VRCodeReviewPolicy](https://github.com/vrsoftbr/VRCodeReviewPolicy).

## Conteúdo

- `.github/workflows/claude-review.yml` — o workflow em si.
- `README.md` — nova seção "Claude PR Review (claude-review.yml)" seguindo o padrão dos demais (Inputs · Secrets · Exemplo inline).

## Como a política é resolvida

O workflow faz checkout do repo de policy (default: `vrsoftbr/VRCodeReviewPolicy@main`) e compõe três camadas em `.claude/review-policy.md` no runner antes de invocar o Claude:

1. **default** — `instructions/default.md` (sempre aplicada)
2. **stack** — `instructions/stacks/<stack>.md` (opcional, via input `stack`)
3. **projeto** — `instructions/projects/<project>.md` (opcional, via input `project`)

Camadas mais específicas têm precedência. Como toda a policy vive no repo central, mudanças de regras não exigem tocar no repo do projeto.

## Dependências

- **Repositório de policy:** depende de `vrsoftbr/VRCodeReviewPolicy` ter sido inicializado com pelo menos `instructions/default.md`. Ver PR [vrsoftbr/VRCodeReviewPolicy#1](https://github.com/vrsoftbr/VRCodeReviewPolicy/pull/1).
- **Secrets a nível de org:** `CLAUDE_CODE_OAUTH_TOKEN`, `JIRA_USERNAME`, `JIRA_API_TOKEN` (obrigatórios) e `POLICY_REPO_TOKEN` (opcional, só se o repo de policy for privado).
- **Imagem MCP:** `ghcr.io/sooperset/mcp-atlassian:latest` (pré-pull no job).
- **Action externa:** `anthropics/claude-code-action@v1`.

## Como testar / validar

- [ ] Conferir `Inputs`/`Secrets` documentados no README e bater com os declarados no workflow.
- [ ] Validar o exemplo do README (`uses: vrsoftbr/reusable-workflows/.github/workflows/claude-review.yml@main` + `stack: java` + `project: vrpdv`).
- [ ] Após merge da [PR de policy](https://github.com/vrsoftbr/VRCodeReviewPolicy/pull/1), abrir um PR pequeno em algum repo (ex.: `vrsoftbr/VRPdv`) com o caller workflow e verificar se o comentário consolidado do Claude é publicado.
- [ ] Verificar permissões: `Settings → Actions → General → Access` neste repo precisa liberar uso pelos demais repos do org.

## Próximos passos depois do merge

1. Criar tag `v1` apontando para o commit de merge (boa prática pra os projetos fixarem versão estável).
2. Em `vrsoftbr/VRPdv`, adicionar `.github/workflows/pr-review.yml` chamando este workflow com `stack: java` e `project: vrpdv`.
3. Decidir manutenção dual das instruções do VRPdv: hoje existem em `VRPdv/.github/copilot-instructions.md` (Copilot) e `VRCodeReviewPolicy/instructions/projects/vrpdv.md` (Claude). Definir fonte da verdade.